### PR TITLE
intelephenseでWP_UnitTestCaseの参照エラーが発生している問題の修正

### DIFF
--- a/.devcontainer/.bin/post-create.sh
+++ b/.devcontainer/.bin/post-create.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# プロジェクトルートで実行されていることを確認
+# カレントディレクトリに`package.json`が存在すれば、プロジェクトルートとみなす
+if [ ! -f ./package.json ]; then
+	echo "This script must be run in the root of the project" 1>&2
+	exit 1
+fi
+
+function main() {
+	# カレントユーザーを`wp-env`コマンド実行ユーザーとして指定するために`docker`グループに追加。
+	# ※ `wp-env`コマンドは`root`ユーザーでコンテナを起動できないようになっているため。
+	join_docker_group
+
+	# 現在のディレクトリのパーミッションを変更
+	set_permissions
+
+	# intelephense用のインクルードファイルをインストール
+	install_intelephense_includes
+}
+
+function join_docker_group() {
+	sudo gpasswd -a $(whoami) docker
+}
+
+function set_permissions() {
+	# ファイルのパーミッションを変更
+	sudo chown -R $(whoami):$(whoami) .
+}
+
+
+function install_intelephense_includes() {
+	# 変数WP_VERSIONにWordPressのバージョンを設定
+	WP_VERSION=5.4.15
+
+	INCLUDES_DIR=./.devcontainer/.intelephense-includes/wordpress-develop-${WP_VERSION}/tests/phpunit/includes
+	# INCLUDES_DIRが存在する場合は処理抜け
+	if [ -d $INCLUDES_DIR ]; then
+		return
+	fi
+
+	# INCLUDES_DIRを作成し、WordPressのテスト用ファイルをダウンロード
+	mkdir -p $INCLUDES_DIR
+	curl -L https://github.com/WordPress/wordpress-develop/archive/refs/tags/${WP_VERSION}.tar.gz | tar zx -C /tmp
+	mv /tmp/wordpress-develop-${WP_VERSION}/tests/phpunit/includes $INCLUDES_DIR
+	rm -rf /tmp/wordpress-develop-${WP_VERSION}
+}
+
+
+main

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,9 +11,7 @@
 		"compose.devcontainer.yml"
 	],
 
-	// `ubuntu`を`wp-env`コマンド実行ユーザーとして指定するために`docker`グループに追加。
-	// ※ `wp-env`コマンドは`root`ユーザーでコンテナを起動できないようになっているため。
-	"postCreateCommand": "sudo gpasswd -a ubuntu docker && sudo chown -R ubuntu:ubuntu /workspaces && npm install",
+	"postCreateCommand": "bash .devcontainer/.bin/post-create.sh",
 	// コンテナ起動のたびに開発用WordPress環境及びphpMyAdminを含むコンテナを立ち上げる
 	"postStartCommand": "npm run env:start && npm run my-docker:start",
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 # publicディレクトリはリリースファイル(zip)に含めるが、Git管理は行わない
 /public
 
+.devcontainer/.intelephense-includes
+
 # 開発中作業ディレクトリ
 /.work-www
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,7 @@
 {
-	"git.autorefresh": true
+	"git.autorefresh": true,
+	"intelephense.environment.phpVersion": "7.4",
+	"intelephense.environment.includePaths": [
+		".devcontainer/.intelephense-includes/wordpress-develop-5.4.15/tests/phpunit/includes/includes"
+	]
 }

--- a/phpunit/classes/Lib/Env/Env-test.php
+++ b/phpunit/classes/Lib/Env/Env-test.php
@@ -1,10 +1,8 @@
 <?php
 
 use Cornix\Serendipity\Core\Lib\Env\Env;
-use Cornix\Serendipity\Core\Lib\Path\LocalPath;
-use Yoast\WPTestUtils\BrainMonkey\TestCase;
 
-class EnvTest extends TestCase {
+class EnvTest extends WP_UnitTestCase {
 
 	protected function set_up() {
 		parent::set_up();

--- a/phpunit/classes/Lib/HandleName/HandleName-test.php
+++ b/phpunit/classes/Lib/HandleName/HandleName-test.php
@@ -1,9 +1,8 @@
 <?php
 
 use Cornix\Serendipity\Core\Lib\HandleName\HandleName;
-use Yoast\WPTestUtils\BrainMonkey\TestCase;
 
-class HandleNameTest extends TestCase {
+class HandleNameTest extends WP_UnitTestCase {
 
 	protected function set_up() {
 		parent::set_up();

--- a/phpunit/classes/Lib/Path/LocalPath-test.php
+++ b/phpunit/classes/Lib/Path/LocalPath-test.php
@@ -1,9 +1,8 @@
 <?php
 
 use Cornix\Serendipity\Core\Lib\Path\LocalPath;
-use Yoast\WPTestUtils\BrainMonkey\TestCase;
 
-class LocalPathTest extends TestCase {
+class LocalPathTest extends WP_UnitTestCase {
 
 	protected function set_up() {
 		parent::set_up();

--- a/phpunit/classes/Lib/Path/Url-test.php
+++ b/phpunit/classes/Lib/Path/Url-test.php
@@ -1,9 +1,8 @@
 <?php
 
 use Cornix\Serendipity\Core\Lib\Path\Url;
-use Yoast\WPTestUtils\BrainMonkey\TestCase;
 
-class UrlTest extends TestCase {
+class UrlTest extends WP_UnitTestCase {
 
 	protected function set_up() {
 		parent::set_up();

--- a/phpunit/classes/Lib/Plugin/Plugin-test.php
+++ b/phpunit/classes/Lib/Plugin/Plugin-test.php
@@ -1,9 +1,8 @@
 <?php
 
 use Cornix\Serendipity\Core\Lib\Plugin\Plugin;
-use Yoast\WPTestUtils\BrainMonkey\TestCase;
 
-class PluginTest extends TestCase {
+class PluginTest extends WP_UnitTestCase {
 
 	protected function set_up() {
 		parent::set_up();

--- a/phpunit/classes/Lib/Strings/Strings-test.php
+++ b/phpunit/classes/Lib/Strings/Strings-test.php
@@ -1,9 +1,8 @@
 <?php
 
 use Cornix\Serendipity\Core\Lib\Strings\Strings;
-use Yoast\WPTestUtils\BrainMonkey\TestCase;
 
-class StringsTest extends TestCase {
+class StringsTest extends WP_UnitTestCase {
 
 	protected function set_up() {
 		parent::set_up();


### PR DESCRIPTION
以下の対応を行った
- wordpress-developのtestsフォルダ内にあるphpunit用のincludesファイルをintelephenseが参照できるように設定